### PR TITLE
Upgrade: Bump marked from 4.3.0 to 18.0.0

### DIFF
--- a/js/mdRenderer.js
+++ b/js/mdRenderer.js
@@ -11,34 +11,27 @@ function imageReplace(s) {
 */
 export default function render(text) {
   // overrides for the Marked HTML renderer
-  marked.use({ 
+  marked.use({
     renderer: {
-      heading(value, level) {
-        var tag = `h${level}`;
-        return `<${tag}>${value}</${tag}>`;
+      code({ text }) {
+        return `<div class="source_code" style="white-space: pre-wrap;">${hl.highlightAuto(text).value}</div>`;
       },
-      code(value) {
-        return `<div class="source_code" style="white-space: pre-wrap;">${hl.highlightAuto(value).value}</div>`;
+      codespan({ text }) {
+        return `<span class="source_code inline">${text}</span>`;
       },
-      codespan(value) {
-        return `<span class="source_code inline">${value}</span>`;
+      image({ href, title, text }) {
+        return `<a href="${href}"><img class='media' title="${title || ''}" alt="${text || ''}" src="${imageReplace(href)}" /></a>`;
       },
-      blockquote(value) {
-        return `<div class="blockquote">${value}</div>`;
-      },
-      image(href, title, alt) {
-        return `<a href="${href}"><img class='media' title="${title}" alt="${alt}" src="${imageReplace(href)}" /></a>`;
-      },
-      html(value) { // TODO this is only block-level
-        if(!value) return;
-        var match = value.match(/<(.*?)\s/);
+      html({ text }) { // TODO this is only block-level
+        if(!text) return;
+        var match = text.match(/<(.*?)\s/);
         if(match) {
-          var name = value.match(/<(.*?)\s/)[1];
+          var name = text.match(/<(.*?)\s/)[1];
           if(name === "youtube") {
-            return `<div class='youtubeWrapper'><div class='inner'><iframe frameborder='0' allowfullscreen='' src='https://www.youtube.com/embed/${value.match(/video-id="(.*)"/)[1]}?rel=0&amp;showinfo=0' allowfullscreen></iframe></div></div>`;
+            return `<div class='youtubeWrapper'><div class='inner'><iframe frameborder='0' allowfullscreen='' src='https://www.youtube.com/embed/${text.match(/video-id="(.*)"/)[1]}?rel=0&amp;showinfo=0' allowfullscreen></iframe></div></div>`;
           }
         }
-        return value;
+        return text;
       }
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "finalhandler": "2.1.1",
         "highlight.js": "^11.4.0",
         "less": "4.6.4",
-        "marked": "^4.0.12",
+        "marked": "^18.0.0",
         "minimist": "^1.2.5",
         "open": "^10.0.0",
         "prompts": "^2.4.0",
@@ -388,15 +388,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "finalhandler": "2.1.1",
     "highlight.js": "^11.4.0",
     "less": "4.6.4",
-    "marked": "^4.0.12",
+    "marked": "^18.0.0",
     "minimist": "^1.2.5",
     "open": "^10.0.0",
     "prompts": "^2.4.0",


### PR DESCRIPTION
### Fixes #46

### Upgrade
- Bump `marked` from 4.3.0 to 18.0.0

### Update
- Update all renderer methods to the v13+ token-object API (single token arg instead of positional args)
- Remove redundant `heading` renderer (marked v8+ no longer adds `id` attributes)
- Remove `blockquote` renderer in favour of default `<blockquote>` output (existing element styles in `built-ins.less` now apply)

### Testing
- [ ] Render a page with fenced code blocks — verify highlight.js auto-detection still works
- [ ] Render inline code spans — verify `<span class="source_code inline">` wrapping
- [ ] Render blockquotes — verify `<blockquote>` element styling (italic, left border)
- [ ] Render images — verify `<a>` link wrapping and `file://` path rewrite
- [ ] Render a `<youtube video-id="...">` tag — verify iframe embedding
- [ ] Visually compare a rendered page before and after the upgrade